### PR TITLE
Shelter additional constraints

### DIFF
--- a/app/controllers/pet_applications_controller.rb
+++ b/app/controllers/pet_applications_controller.rb
@@ -9,7 +9,6 @@ class PetApplicationsController < ApplicationController
       pet.update(adoption_status: "Adoptable")
       redirect_to "/applications/#{application.id}"
     end
-    # require "pry"; binding.pry
   end
 
   private

--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -27,7 +27,10 @@ class SheltersController < ApplicationController
 
   def destroy
     shelter = Shelter.find(params[:id])
-    shelter.destroy
+    if shelter.has_all_adoptable_pets?
+      shelter.delete_pets
+      shelter.destroy
+    end
     redirect_to '/shelters'
   end
 

--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -29,6 +29,7 @@ class SheltersController < ApplicationController
     shelter = Shelter.find(params[:id])
     if shelter.has_all_adoptable_pets?
       shelter.delete_pets
+      shelter.delete_reviews
       shelter.destroy
     end
     redirect_to '/shelters'

--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -11,8 +11,13 @@ class SheltersController < ApplicationController
   end
 
   def create
-    Shelter.create(shelter_params)
-    redirect_to '/shelters'
+    shelter = Shelter.new(shelter_params)
+    if !shelter.save
+      flash[:failure] = "Oh no! Please fill out missing fields before hitting the submit button."
+      redirect_to '/shelters/new'
+    else
+      redirect_to '/shelters'
+    end
   end
 
   def edit
@@ -21,9 +26,17 @@ class SheltersController < ApplicationController
 
   def update
     shelter = Shelter.find(params[:id])
-    shelter.update(shelter_params)
-    redirect_to "/shelters/#{shelter.id}"
+    shelter.assign_attributes(shelter_params)
+    if !shelter.save
+      flash[:failure] = "Oh no! Please fill out missing fields before hitting the submit button."
+      redirect_to "/shelters/#{shelter.id}/edit"
+    else
+      redirect_to "/shelters/#{shelter.id}"
+    end
   end
+
+  # create = new + save
+  # update = asssign_attributes + save
 
   def destroy
     shelter = Shelter.find(params[:id])

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -7,4 +7,5 @@ class Pet < ApplicationRecord
   validates_presence_of :name
   validates_presence_of :age
   validates_presence_of :sex
+
 end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -28,4 +28,18 @@ class Shelter < ApplicationRecord
   def delete_reviews
     self.reviews.each { |review| review.destroy }
   end
+
+  def pets_count
+    self.pets.count
+  end
+
+  def avg_shelter_review
+    Review.average(:rating)
+  end
+
+  def applications_count
+    self.pets.sum do |pet|
+      pet.applications.count
+    end
+  end
 end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -22,7 +22,10 @@ class Shelter < ApplicationRecord
   def delete_applications(pet)
     pet.applications.each do |application|
       application.pets.delete(pet)
-    end 
+    end
   end
 
+  def delete_reviews
+    self.reviews.each { |review| review.destroy }
+  end
 end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -7,4 +7,9 @@ class Shelter < ApplicationRecord
   validates_presence_of :city
   validates_presence_of :state
   validates_presence_of :zip
+
+  def has_approved_pets?
+    self.pets.any? { |pet| pet.adoption_status != "Adoptable" }
+  end
+
 end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -8,8 +8,21 @@ class Shelter < ApplicationRecord
   validates_presence_of :state
   validates_presence_of :zip
 
-  def has_approved_pets?
-    self.pets.any? { |pet| pet.adoption_status != "Adoptable" }
+  def has_all_adoptable_pets?
+    self.pets.all? { |pet| pet.adoption_status == "Adoptable" }
+  end
+
+  def delete_pets
+    self.pets.each do |pet|
+      delete_applications(pet)
+      pet.destroy
+    end
+  end
+
+  def delete_applications(pet)
+    pet.applications.each do |application|
+      application.pets.delete(pet)
+    end 
   end
 
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
 
 <body>
   <nav class="navbar sticky-top navbar-light bg-light">
-    <%= button_to "Shelters", "/shelters", class: "btn btn-outline-secondary" %>
+    <%= button_to "Shelters", "/shelters", class: "btn btn-outline-secondary", method: :get %>
     <%= button_to "Pets", "/pets", class: "btn btn-outline-secondary", method: :get %>
     <% if session[:favorites] != nil %>
       <%= button_to "My Favorites: #{session[:favorites].count}", "/favorites", class: "btn btn-info", method: :get %>

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -11,7 +11,7 @@
   <%= link_to 'All Our Pets', "/shelters/#{@shelter.id}/pets", class: "btn btn-success" %>
   <%= link_to 'Update Shelter', "/shelters/#{@shelter.id}/edit", class: "btn btn-primary" %>
   <%= link_to 'Add a Review', "/shelters/#{@shelter.id}/reviews/new", class: "btn btn-info" %>
-  <% if !@shelter.has_approved_pets? %>
+  <% if @shelter.has_all_adoptable_pets? %>
     <%= button_to 'Delete Shelter', "/shelters/#{@shelter.id}", method: :delete, class: "btn btn-danger" %>
   <% end %>
 </div>

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -1,5 +1,12 @@
 <h2><%= @shelter.name %></h2>
 
+<nav class="navbar navbar-light bg-light">
+  <span class="navbar-brand mb-0"><%= "Count of Pets: #{@shelter.pets_count}" %></span>
+  <span class="navbar-brand mb-0"><%= "Average Review Rating: #{@shelter.avg_shelter_review}" %></span>
+  <span class="navbar-brand mb-0"><%= "Applications of File: #{@shelter.applications_count}" %></span>
+</nav>
+
+
 <ul class="list-group">
   <li class="list-group-item">Address: <%= @shelter.address %></li>
   <li class="list-group-item">City: <%= @shelter.city %></li>

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -10,8 +10,10 @@
 <div class="button">
   <%= link_to 'All Our Pets', "/shelters/#{@shelter.id}/pets", class: "btn btn-success" %>
   <%= link_to 'Update Shelter', "/shelters/#{@shelter.id}/edit", class: "btn btn-primary" %>
-  <%= link_to 'Delete Shelter', "/shelters/#{@shelter.id}", method: :delete, class: "btn btn-danger" %>
   <%= link_to 'Add a Review', "/shelters/#{@shelter.id}/reviews/new", class: "btn btn-info" %>
+  <% if !@shelter.has_approved_pets? %>
+    <%= button_to 'Delete Shelter', "/shelters/#{@shelter.id}", method: :delete, class: "btn btn-danger" %>
+  <% end %>
 </div>
 
 <% @shelter.reviews.each do |review| %>

--- a/spec/features/shelters/delete_spec.rb
+++ b/spec/features/shelters/delete_spec.rb
@@ -60,5 +60,22 @@ describe 'As a user', type: :feature do
     expect(page).not_to have_content(@pet1.name)
     expect(page).not_to have_content(@pet2.name)
   end
-  
+
+  it 'deletes reviews along with shelter' do
+    review1 = Review.create!(title: "Best Shelter!", rating: 5, content: "Very nice people and adorable pets.", shelter: @shelter)
+
+    review2 = Review.create!(title: "Best Shelter!", rating: 5, content: "Very nice people and adorable pets.", shelter: @shelter)
+
+    review3 = Review.create!(title: "Best Shelter!", rating: 5, content: "Very nice people and adorable pets.", shelter: @shelter1)
+
+    visit "/shelters/#{@shelter.id}"
+
+    expect(page).to have_content(review1.title)
+
+    click_on 'Delete Shelter'
+
+    expect(Review.all.include?(review1)).to eq(false)
+    expect(Review.all.include?(review2)).to eq(false)
+    expect(Review.all.include?(review3)).to eq(true)
+  end
 end

--- a/spec/features/shelters/delete_spec.rb
+++ b/spec/features/shelters/delete_spec.rb
@@ -42,4 +42,30 @@ describe 'As a user', type: :feature do
     expect(page).to have_content(@shelter.name)
     expect(page).to_not have_button("Delete Shelter")
   end
+
+  it "shelters can be deleted as long as all pets don't have approved applications on them" do
+
+    visit "/pets/#{@pet1.id}"
+    click_link "Favorite Me!"
+
+    visit "/pets/#{@pet2.id}"
+    click_link "Favorite Me!"
+
+    visit "/shelters/#{@shelter.id}"
+    click_on 'Delete Shelter'
+    expect(current_path).to eq('/shelters')
+    expect(page).not_to have_content(@shelter.name)
+
+    visit "/pets"
+    expect(page).not_to have_content(@pet1.name)
+    expect(page).not_to have_content(@pet2.name)
+  end
+
+#   User Story 27, Shelters can be Deleted as long as all pets do not have approved applications on them
+#
+# As a visitor
+# If a shelter doesn't have any pets with a pending status
+# I can delete that shelter
+# When that shelter is deleted
+# Then all of their pets are deleted as well
 end

--- a/spec/features/shelters/delete_spec.rb
+++ b/spec/features/shelters/delete_spec.rb
@@ -60,12 +60,5 @@ describe 'As a user', type: :feature do
     expect(page).not_to have_content(@pet1.name)
     expect(page).not_to have_content(@pet2.name)
   end
-
-#   User Story 27, Shelters can be Deleted as long as all pets do not have approved applications on them
-#
-# As a visitor
-# If a shelter doesn't have any pets with a pending status
-# I can delete that shelter
-# When that shelter is deleted
-# Then all of their pets are deleted as well
+  
 end

--- a/spec/features/shelters/delete_spec.rb
+++ b/spec/features/shelters/delete_spec.rb
@@ -1,22 +1,45 @@
-# As a visitor
-# When I visit a shelter show page
-# Then I see a link to delete the shelter
-# When I click the link "Delete Shelter"
-# Then a 'DELETE' request is sent to '/shelters/:id',
-# the shelter is deleted,
-# and I am redirected to the shelter index page where I no longer see this shelter
 require 'rails_helper'
 
 describe 'As a user', type: :feature do
-  it 'I can delete a shelter' do
-    shelter = Shelter.create!(name: 'First Shelter', address: '1st St.', city: 'Bakersfield', state: 'CA', zip: 93303)
 
-    visit "/shelters/#{shelter.id}"
+  before(:each) do
+    @shelter = Shelter.create!(name: 'Cat Shelter', address: '2nd St.', city: 'Los Angeles', state: 'CA', zip: 93303)
+    @shelter1 = Shelter.create!(name: 'Puppy Shelter', address: '2nd St.', city: 'Los Angeles', state: 'CA', zip: 93303)
+
+    @pet1 = Pet.create!(image: 'img001.png', name: 'Lukas', age: 10, sex: 'Male', shelter: @shelter, description: "I'm a good boy", adoption_status: 'Adoptable')
+    @pet2 = Pet.create!(image: '03.jpg', name: 'Bubba', age: 5, sex: 'Female', shelter: @shelter, description: "I'm the best", adoption_status: 'Adoptable')
+    @application1 = Application.create!(name: "Elah Pillado", address: "123 SW Gate", city: "Marietta", state: "GA", zip: 30008, phone_number: "7735551224", description: "I'm a very responsible person and I will love them forever!")
+    PetApplication.create(application: @application1, pet: @pet1)
+    PetApplication.create(application: @application1, pet: @pet2)
+  end
+
+  it 'I can delete a shelter' do
+
+    visit "/shelters/#{@shelter1.id}"
 
     click_on 'Delete Shelter'
 
     expect(current_path).to eq('/shelters')
 
-    expect(page).not_to have_content(shelter.name)
+    expect(page).not_to have_content(@shelter1.name)
+  end
+
+  it "shelters with pets that have pending status cannot be deleted" do
+
+    visit "/pets/#{@pet1.id}"
+    click_link "Favorite Me!"
+
+    visit "/applications/#{@application1.id}"
+
+    within("#pet-#{@pet1.id}") do
+      expect(page).to have_link("Approve")
+      click_on "Approve"
+    end
+
+    visit "/shelters/#{@shelter.id}"
+
+    expect(current_path).to eq("/shelters/#{@shelter.id}")
+    expect(page).to have_content(@shelter.name)
+    expect(page).to_not have_button("Delete Shelter")
   end
 end

--- a/spec/features/shelters/new_spec.rb
+++ b/spec/features/shelters/new_spec.rb
@@ -17,11 +17,7 @@ describe 'New Shelter', type: :feature do
         fill_in 'State', with: 'CA'
         fill_in 'Zip', with: 93303
 
-        
-
         click_on 'Create Shelter'
-
-        
 
         shelter = Shelter.last
 

--- a/spec/features/shelters/new_spec.rb
+++ b/spec/features/shelters/new_spec.rb
@@ -24,6 +24,27 @@ describe 'New Shelter', type: :feature do
         expect(current_path).to eq('/shelters')
         expect(page).to have_content(shelter.name)
       end
+
+      it 'I cannot create a new shelter with missing information' do
+
+        visit '/shelters'
+
+        click_link 'New Shelter'
+
+        expect(current_path).to eq('/shelters/new')
+
+        fill_in 'Name', with: ''
+        fill_in 'Address', with: ''
+        fill_in 'City', with: ''
+        fill_in 'State', with: ''
+        fill_in 'Zip', with: 93303
+
+        click_on 'Create Shelter'
+
+        expect(page).to have_content("Oh no! Please fill out missing fields before hitting the submit button.")
+
+        expect(current_path).to eq('/shelters/new')
+      end
     end
   end
 end

--- a/spec/features/shelters/show_spec.rb
+++ b/spec/features/shelters/show_spec.rb
@@ -41,4 +41,24 @@ describe 'shelters show page shows shelter with that id', type: :feature do
     expect(page).to have_content(review2.content)
     expect(page.find('img')['src']).to have_content(review2.picture)
   end
+
+  it 'can display statistics' do
+    pet1 = Pet.create!(image: 'img001.png', name: 'Olaf', age: 3, sex: 'Male', shelter: @shelter1)
+    pet2 = Pet.create!(image: 'img002.png',name: 'Kitty', age: 7, sex: 'Female', shelter: @shelter1)
+
+    review1 = Review.create!(title: "Best Shelter!", rating: 5, content: "Very nice people and adorable pets.", shelter: @shelter1)
+    review2 = Review.create!(title: "Best Shelter!", rating: 5, content: "Very nice people and adorable pets.", picture:"https://storage.googleapis.com/wordpress-www-vendasta/Top-14-Review-Sites-fb.jpg", shelter: @shelter1)
+
+    application1 = Application.create!(name: "Elah Pillado", address: "123 SW Gate", city: "Marietta", state: "GA", zip: 30008, phone_number: "7735551224", description: "I'm a very responsible person and I will love them forever!")
+    PetApplication.create(application: application1, pet: pet1)
+    PetApplication.create(application: application1, pet: pet2)
+
+    visit "/shelters/#{@shelter1.id}"
+
+    save_and_open_page
+
+    expect(page).to have_content("Count of Pets: #{@shelter1.pets_count}")
+    expect(page).to have_content("Average Review Rating: #{@shelter1.avg_shelter_review}")
+    expect(page).to have_content("Applications of File: #{@shelter1.applications_count}")
+  end
 end

--- a/spec/features/shelters/show_spec.rb
+++ b/spec/features/shelters/show_spec.rb
@@ -55,8 +55,6 @@ describe 'shelters show page shows shelter with that id', type: :feature do
 
     visit "/shelters/#{@shelter1.id}"
 
-    save_and_open_page
-
     expect(page).to have_content("Count of Pets: #{@shelter1.pets_count}")
     expect(page).to have_content("Average Review Rating: #{@shelter1.avg_shelter_review}")
     expect(page).to have_content("Applications of File: #{@shelter1.applications_count}")

--- a/spec/features/shelters/update_spec.rb
+++ b/spec/features/shelters/update_spec.rb
@@ -1,20 +1,3 @@
-# User Story 5, Shelter Update
-#
-# As a visitor
-# When I visit a shelter show page
-# Then I see a link to update the shelter "Update Shelter"
-# When I click the link "Update Shelter"
-# Then I am taken to '/shelters/:id/edit' where I  see a form to edit the shelter's data including:
-# - name
-# - address
-# - city
-# - state
-# - zip
-# When I fill out the form with updated information
-# And I click the button to submit the form
-# Then a `PATCH` request is sent to '/shelters/:id',
-# the shelter's info is updated,
-# and I am redirected to the Shelter's Show page where I see the shelter's updated info
 require 'rails_helper'
 
 describe 'As a user', type: :feature do
@@ -40,8 +23,6 @@ describe 'As a user', type: :feature do
     fill_in 'Zip', with: new_zip
 
     click_on 'Update Shelter'
-
-    
 
     expect(page).to have_content(new_name)
     expect(page).to have_content(new_address)

--- a/spec/features/shelters/update_spec.rb
+++ b/spec/features/shelters/update_spec.rb
@@ -30,4 +30,32 @@ describe 'As a user', type: :feature do
     expect(page).to have_content(new_state)
     expect(page).to have_content(new_zip)
   end
+
+  it 'I can see a flash message if not all required info given to update a shelter' do
+    shelter = Shelter.create!(name: 'First Shelter', address: '1st St.', city: 'Bakersfield', state: 'CA', zip: 93303)
+
+    visit "/shelters/#{shelter.id}"
+
+    click_on 'Update Shelter'
+
+    expect(current_path).to eq("/shelters/#{shelter.id}/edit")
+
+    new_name = ''
+    new_address = ''
+    new_city = ''
+    new_state = ''
+    new_zip = 99993303
+
+    fill_in 'Name', with: new_name
+    fill_in 'Address', with: new_address
+    fill_in 'City', with: new_city
+    fill_in 'State', with: new_state
+    fill_in 'Zip', with: new_zip
+
+    click_on 'Update Shelter'
+
+    expect(page).to have_content("Oh no! Please fill out missing fields before hitting the submit button.")
+
+    expect(current_path).to eq("/shelters/#{shelter.id}/edit")
+  end
 end


### PR DESCRIPTION
Create additional constraints for shelters:
- Shelters with Pets that have pending status cannot be Deleted
- Shelters can be Deleted as long as all pets do not have approved applications on them
- Deleting Shelters Deletes its Reviews
- Flash Messages for Shelter Create and Update
- Shelter Statistics
